### PR TITLE
ci: speed up tests with xdist (2.92s → 2.15s, -26%), keep 100% coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,21 +1,57 @@
 pipeline {
-    agent any
+  agent { docker { image 'python:3.11-slim' } }
+  options { timestamps(); ansiColor('xterm'); buildDiscarder(logRotator(numToKeepStr: '30')) }
 
-    stages {
-        stage('Clone') {
-            steps {
-                git 'https://github.com/OH-SEONGBIN/jenkins-cicd-python-demo.git'
-            }
-        }
-        stage('Install Dependencies') {
-            steps {
-                sh 'pip install pytest'
-            }
-        }
-        stage('Test') {
-            steps {
-                sh 'pytest'
-            }
-        }
+  stages {
+    stage('Checkout'){ steps { checkout scm } }
+
+    stage('Setup'){
+      steps {
+        sh '''
+          set -eux
+          python -V
+          pip install -U pip wheel
+          pip install -r requirements.txt -r requirements-dev.txt
+          mkdir -p reports metrics
+          export PYTHONPATH=src
+        '''
+      }
     }
+
+    stage('Lint'){
+      steps {
+        sh '''
+          flake8 src tests | tee reports/flake8.txt || true
+        '''
+      }
+    }
+
+    stage('Tests (xdist)'){
+      steps {
+        sh '''
+          export PYTHONPATH=src
+          pytest -n auto --junitxml=reports/junit.xml \
+                 --cov=src --cov-report=xml:reports/coverage.xml --cov-report=term
+        '''
+      }
+    }
+
+    stage('Metrics'){
+      steps {
+        sh '''
+          python tools/ci_metrics.py --junit reports/junit.xml \
+                                     --cov reports/coverage.xml \
+                                     --flake reports/flake8.txt \
+                                     --out metrics/ci_metrics.csv
+        '''
+      }
+    }
+  }
+
+  post {
+    always {
+      junit 'reports/junit.xml'
+      archiveArtifacts artifacts: 'reports/**,metrics/**', fingerprint: true
+    }
+  }
 }

--- a/metrics/ci_metrics.csv
+++ b/metrics/ci_metrics.csv
@@ -1,0 +1,3 @@
+commit,tests,passed,failures,errors,skipped,pass_ratio,junit_time_sec,coverage_pct,lint_count
+,7,7,0,0,0,100.0,2.92,100.0,8
+,7,7,0,0,0,100.0,2.15,100.0,8

--- a/tools/ci_metrics.py
+++ b/tools/ci_metrics.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import argparse, csv, os, time
+from xml.etree import ElementTree as ET
+from pathlib import Path
+
+def parse_junit(p):
+    if not Path(p).exists(): return (0,0,0,0,0.0)
+    root = ET.parse(p).getroot()
+    suites = root.findall(".//testsuite") or [root]
+    t=f=e=s=0; total=0.0
+    for su in suites:
+        t+=int(su.attrib.get("tests",0))
+        f+=int(su.attrib.get("failures",0))
+        e+=int(su.attrib.get("errors",0))
+        s+=int(su.attrib.get("skipped",0))
+        total+=float(su.attrib.get("time",0.0))
+    return (t,f,e,s,total)
+
+def parse_cov(p):
+    if not Path(p).exists(): return 0.0
+    root = ET.parse(p).getroot()
+    rate = root.attrib.get("line-rate")
+    return round(float(rate)*100,2) if rate else 0.0
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--junit", required=True)
+    ap.add_argument("--cov",   required=True)
+    ap.add_argument("--flake", default="")
+    ap.add_argument("--out",   default="metrics/ci_metrics.csv")
+    a=ap.parse_args()
+
+    t,f,e,s,total = parse_junit(a.junit)
+    cov = parse_cov(a.cov)
+    lint = sum(1 for _ in open(a.flake,"r",encoding="utf-8")) if a.flake and Path(a.flake).exists() else 0
+    passed = max(0, t-f-e-s)
+    pass_ratio = round((passed/t)*100,2) if t else 0.0
+
+    Path("metrics").mkdir(exist_ok=True)
+    hdr = ["commit","tests","passed","failures","errors","skipped","pass_ratio","junit_time_sec","coverage_pct","lint_count"]
+    row = [os.getenv("GIT_COMMIT",""), t, passed, f, e, s, pass_ratio, round(total,2), cov, lint]
+
+    new = not Path(a.out).exists()
+    with open(a.out,"a",newline="",encoding="utf-8") as f:
+        w = csv.writer(f)
+        if new: w.writerow(hdr)
+        w.writerow(row)
+    print(f"[metrics] pass={pass_ratio}%, cov={cov}%, lint={lint}, junit_time={round(total,2)}s")
+
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
## What
- Add reproducible CI metrics pipeline (junit + coverage + flake8 → CSV)
- Enable pytest-xdist for parallel test execution

## Why
- Show measurable CI improvement with repeatable scripts

## Evidence (metrics/ci_metrics.csv)
- pass_ratio: 100% (unchanged)
- coverage: 100% (unchanged)
- junit_time: 2.92s → 2.15s (**-26%**)
- lint_count: 8 (tracked; to be reduced in next PR)

## How to reproduce
# base
export PYTHONPATH=src
pytest -n 0 --junitxml=reports/junit_base.xml --cov=src --cov-report=xml:reports/cov_base.xml
python tools/ci_metrics.py --junit reports/junit_base.xml --cov reports/cov_base.xml --flake reports/flake8.txt --out metrics/ci_metrics.csv

# xdist
export PYTHONPATH=src
pytest -n auto --junitxml=reports/junit_xdist.xml --cov=src --cov-report=xml:reports/cov_xdist.xml
python tools/ci_metrics.py --junit reports/junit_xdist.xml --cov reports/cov_xdist.xml --flake reports/flake8.txt --out metrics/ci_metrics.csv